### PR TITLE
Mention other implementations under "Software" section

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,9 +175,11 @@
             <div class="box"><div class="vcenter">
                 <h2>Software</h2>
                 <ul>
-                    <li><a href="https://github.com/libjxl/libjxl">JPEG XL reference implementation</a> (libjxl)
+                    <li><a href="https://github.com/libjxl/libjxl">JPEG XL C++ reference implementation</a> (libjxl)
                         <a href="https://artifacts.lucaversari.it/libjxl/libjxl/latest/">(nightly dev builds)</a>
                     </li>
+                    <li><a href="https://github.com/Traneptora/jxlatte">JPEG XL Java decoder implementation</a> (jxlatte)</li>
+                    <li><a href="https://github.com/tirr-c/jxl-oxide">JPEG XL Rust decoder implementation</a> (jxl-oxide)</li>
                     <li>
                         <a href="https://www.google.com/chrome">Chrome</a>: behind a flag since M91, removed since M110.
                         An <a href="https://chrome.google.com/webstore/detail/jpeg-xl-viewer/bkhdlfmkaenamnlbpdfplekldlnghchp">add-on</a> is available.


### PR DESCRIPTION
Adds jxlatte and jxl-oxide to the software list.

this was meant to be apart of a larger pull request I am working on but do to recent news coming out I am submitting this part of it standalone in the meantime.