### PR TITLE
index.html: Add JXL coder and Lightroom classic

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,6 +180,7 @@
                     </li>
                     <li><a href="https://github.com/Traneptora/jxlatte">JPEG XL Java decoder implementation</a> (jxlatte)</li>
                     <li><a href="https://github.com/tirr-c/jxl-oxide">JPEG XL Rust decoder implementation</a> (jxl-oxide)</li>
+                    <li><a href="https://github.com/awxkee/jxl-coder">JPEG XL C/C++ decode and encode implementation for Android</a> (jxl-coder)</li>
                     <li><a href="https://www.apple.com/safari/">Safari</a>: supported since version 17 Beta</li>
                     <li>
                         <a href="https://www.google.com/chrome">Chrome</a>: behind a flag since M91, removed since M110.
@@ -202,6 +203,7 @@
                     <li><a href="https://krita.org">Krita</a>: since version 5.1.0</li>
                     <li><a href="https://www.darktable.org">darktable</a>: since version 4.2.0</li>
                     <li><a href="https://helpx.adobe.com/il_en/camera-raw/using/hdr-output.html">Adobe Camera Raw 15</a></li>
+                    <li><a href="https://helpx.adobe.com/lightroom-classic/help/hdr-output.html">Adobe Lightroom Classic 13</a></li>
                     <li><a href="https://affinity.serif.com">Affinity Photo/Designer 2</a></li>
                     <li><a href="https://github.com/libjxl/libjxl/blob/main/doc/software_support.md">[ More... ]</a>
                 </ul>


### PR DESCRIPTION
Add two entries to index.html:
- [JXL coder](https://github.com/awxkee/jxl-coder)
- Adobe [Lightroom Classic](https://helpx.adobe.com/lightroom-classic/help/hdr-output.html)