### PR TITLE
Remove no-break space causing double space in the CMYK/Printing paragraph

### DIFF
--- a/new/index.html
+++ b/new/index.html
@@ -2679,7 +2679,7 @@
             </div>
             <div data-figma-id="73:4012" class="size-small-1rem-16px"></div>
             <p class="text-l-medium">JPEG XL streamlines image authoring with features like layer support, up to 4099
-               channels for selection masks and spot colors, and CMYK compatibility for print-oriented use cases. It’s
+              channels for selection masks and spot colors, and CMYK compatibility for print-oriented use cases. It’s
               an ideal format for all creative workflows.</p>
           </div>
           <div id="w-node-fdc54816-16c6-c5d7-690d-b2083b442a36-8c10331b" class="container-text-grid">


### PR DESCRIPTION
Literally unreadable.