### PR TITLE
Temp fix for question 3 not rendering correctly

### DIFF
--- a/resources/JPEG-XL_FAQ.md
+++ b/resources/JPEG-XL_FAQ.md
@@ -20,12 +20,12 @@ JPEG XL uses more advanced compression techniques compared to JPEG. It uses the 
 - Smaller file sizes: This translates to faster loading times for web pages and reduced storage requirements – often up to 65% smaller.
 - Improved image quality: JPEG XL offers better image fidelity than all current compression algorithms.
 - Support for forward-looking features:
-    - lossless compression
-    - visually lossless compression
-    - transparency
-    - animation, layers & thumbnails
-    - web-friendly progressive encoding and decoding
-    - improved color accuracy and color gamut through HDR (high dynamic range) and high bit depth support
+    1. lossless compression
+    2. visually lossless compression
+    3. transparency
+    4. animation, layers & thumbnails
+    5. web-friendly progressive encoding and decoding
+    6. improved color accuracy and color gamut through HDR (high dynamic range) and high bit depth support
 - - -
 
 ### Is JPEG XL replacing JPEG?


### PR DESCRIPTION
The nested bullet points after "Support for forward-looking features:" in the third question of the FAQ is not rendering.

There is something fundamentally wrong with how the javascript logic works in `JPEG-XL_FAQ.js`. It was a group effort, but @goodusername123, @Firepal, and I found out that this bug happens when toggling of all the answers to be hidden by default, since nested bullet points don't get unhidden when they should be. 

Having all of the answers open is the simplest way to fix this issue, but I'm assuming that having them closed by default is an intentional design decision. I don't have the time/energy to fix this today, but this will work for now.