### PR TITLE
fix: make jpeg-xl-hero bg fit in >1440p

### DIFF
--- a/css/jpeg-xl-test.webflow.css
+++ b/css/jpeg-xl-test.webflow.css
@@ -4278,6 +4278,10 @@ blockquote {
     position: relative;
   }
 
+  .section-jpeg-xl-hero.gradient-bottom {
+    background-size: 100%;
+  }
+
   .image-wave-2560 {
     width: 100%;
     height: auto;


### PR DESCRIPTION
This PR gives the `.section-jpeg-xl-hero.gradient-bottom` selector in the 1440p media query `background-size: 100%` to stretch since the image is smaller than the monitor width.

<details>
  <summary>Before</summary>
  
![css_before](https://github.com/user-attachments/assets/44936760-d887-47c7-b185-a5c2aca15ab8)
  
</details>

<details>
  <summary>After</summary>
  
![css_after](https://github.com/user-attachments/assets/8e8a4aa4-7116-4b02-8d40-0c136ceb52dc)
  
</details>