### PR TITLE
FAQ: Constrain element query to avoid tagging wrong elements as answers

### DIFF
--- a/resources/JPEG-XL_FAQ.js
+++ b/resources/JPEG-XL_FAQ.js
@@ -54,20 +54,38 @@ document.addEventListener('DOMContentLoaded', () => {
             document.getElementById('usage').innerHTML = usageContent;
             document.getElementById('technical').innerHTML = technicalContent;
 
-            // Assign classes and IDs
-            document.querySelectorAll('h3').forEach(el => {
-                el.id = 'question';
-                el.className = 'text-question-faq';
-                const disclosureIcon = document.createElement('span');
-                disclosureIcon.className = 'disclosure-icon';
-                el.appendChild(disclosureIcon);
-            });
 
-            document.querySelectorAll('p, ul').forEach(el => {
-                el.id = 'answer';
-                el.className = 'text-answer-faq';
-                el.style.display = 'none'; // Ensure all answers are hidden by default
-            });
+            let sectionElements = [
+                document.getElementById('general'),
+                document.getElementById('usage'),
+                document.getElementById('technical')
+            ]
+            
+            while (sectionElements.length) {
+                let section = sectionElements.pop();
+                
+                // Assign classes and IDs
+                section.childNodes.forEach(el => {
+                    // ignore text nodes
+                    if (el.nodeType == 3) { return }
+                    
+                    if (el.tagName.toLowerCase() == 'h3') {
+                        el.id = 'question';
+                        el.className = 'text-question-faq';
+                        
+                        const disclosureIcon = document.createElement('span');
+                        disclosureIcon.className = 'disclosure-icon';
+                        el.appendChild(disclosureIcon);
+                        return;
+                    }
+                    
+                    if (['p','ul'].includes(el.tagName.toLowerCase())) {
+                        el.id = 'answer';
+                        el.className = 'text-answer-faq';
+                        el.style.display = 'none'; // answers hidden by default
+                    }
+                });
+            }
         })
         .catch(error => console.error('Error fetching data:', error));
 
@@ -93,16 +111,14 @@ document.addEventListener('DOMContentLoaded', () => {
             if (answer.tagName.toLowerCase() === 'hr') {
                 // Always keep hr visible
                 answer.style.display = 'block';
+            }
+            
+            if (answer.style.display === 'none') {
+                answer.style.display = 'block';
+                answer.style.maxHeight = answer.scrollHeight + 'px';
             } else {
-                if (answer.style.display === 'none') {
-                    answer.style.display = 'block';
-                    answer.style.maxHeight = answer.scrollHeight + 'px';
-                } else {
-                    answer.style.maxHeight = '0px';
-                    setTimeout(() => {
-                        answer.style.display = 'none';
-                    }, 300);
-                }
+                answer.style.display = 'none';
+                answer.style.maxHeight = '0px';
             }
         });
     }

--- a/resources/JPEG-XL_FAQ.md
+++ b/resources/JPEG-XL_FAQ.md
@@ -20,12 +20,12 @@ JPEG XL uses more advanced compression techniques compared to JPEG. It uses the 
 - Smaller file sizes: This translates to faster loading times for web pages and reduced storage requirements – often up to 65% smaller.
 - Improved image quality: JPEG XL offers better image fidelity than all current compression algorithms.
 - Support for forward-looking features:
-    1. lossless compression
-    2. visually lossless compression
-    3. transparency
-    4. animation, layers & thumbnails
-    5. web-friendly progressive encoding and decoding
-    6. improved color accuracy and color gamut through HDR (high dynamic range) and high bit depth support
+    - lossless compression
+    - visually lossless compression
+    - transparency
+    - animation, layers & thumbnails
+    - web-friendly progressive encoding and decoding
+    - improved color accuracy and color gamut through HDR (high dynamic range) and high bit depth support
 - - -
 
 ### Is JPEG XL replacing JPEG?


### PR DESCRIPTION
In the FAQ, questions and answers are stored in a flat hierarchy under "sections", making showing and hiding answers easy as you just have to walk through next siblings, hide siblings labelled as answers and stop when you find a question.

The code tagging elements as a "question" or "answer" was naive, checking the *entire document tree* for the `<ul>` and `<p>` tags. If an answer had either of these as a child, that child would *never* be walked, thus never shown.

This PR makes use of the "section" elements, replacing the document-wide search with a simple walk of the sections' children, fixing the aforementioned problem. This has the following effects:
- This fixes the invisible unordered list "false answer" in the third question's answer (what #32 was about)
- Those HTML tags should now be freely usable elsewhere in the document without being affected by the main FAQ code.