### PR TITLE
Commenting out scripts that aren't currently in use

### DIFF
--- a/index.html
+++ b/index.html
@@ -2746,7 +2746,7 @@
   <script src="script.js"></script>
   <script src="JPEGvsJXL.js"></script>
   <script src="AVIFvsJXL.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/7.0.0/pixi.min.js"></script>
+<!--  <script src="https://cdnjs.cloudflare.com/ajax/libs/pixi.js/7.0.0/pixi.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.9.1/gsap.min.js"></script>
   <script>
     const initNoise = async () => {
@@ -2803,7 +2803,7 @@
       })
     }
     // initNoise()
-  </script>
+  </script> -->
   <script src="js/webflow.js" type="text/javascript"></script>
 </body>
 


### PR DESCRIPTION
If we're hiding the Pixel Noise, we might as well not import the two scripts it required.