### PR TITLE
Added Light Matter to supported image viewer list

### DIFF
--- a/resources/supported-software.html
+++ b/resources/supported-software.html
@@ -566,7 +566,8 @@
                       class="link-text-body-underline">jpegview<br>‍</a>
                     <a href="https://github.com/artemsen/swayimg" class="link-text-body-underline">Swayimg<br>‍</a>
                     <a href="https://mihon.app/" class="link-text-body-underline">Mihon<br>‍</a>
-                    <a href="https://www.xnview.com/en/" class="link-text-body-underline">XnView<br>‍</a>Any viewer
+                    <a href="https://www.xnview.com/en/" class="link-text-body-underline">XnView<br>‍</a>
+                    <a href="https://github.com/Auxx/light-matter" class="link-text-body-underline">Light Matter<br>‍</a>Any viewer
                     based on Qt, KDE, GDK-pixbuf, EFL, ImageMagick, libvips or imlib2 (see above)<br>Qt viewers:
                     gwenview, digiKam, KolourPaint, KPhotoAlbum, LXImage-Qt, qimgv, qView, nomacs, VookiImageViewer,
                     PhotoQt<br>GTK viewers: Eye of Gnome (eog), gThumb, Geeqie<br>EFL viewers: entice, ephoto


### PR DESCRIPTION
Light Matter supports JPEG XL in SDR and HDR on Windows.